### PR TITLE
add random parameter and expand test coverage

### DIFF
--- a/src/k_means.py
+++ b/src/k_means.py
@@ -17,7 +17,7 @@ class Kmeans:
         algorithm.
     '''
 
-    def initialize_centroids(self, matrix: np.ndarray, number_of_centroids: int):
+    def initialize_centroids(self, matrix: np.ndarray, number_of_centroids: int, random_state: int = None):
         '''
         Initializes centroids for clusters. The first centroid is selected randomly from the documents. The next centroids will
         be given the coordinates of the farthest document from other centroids.
@@ -25,12 +25,14 @@ class Kmeans:
         Args:
             matrix (np.ndarray): TF-IDF matrix.
             number_of_centroids (int): An integer indicating the desired number of clusters.
+            random_state (int, optional): Random seed for reproducibility. Defaults to None.
 
         Returns:
             centroid_coordinates (np.ndarray): An array of centroid coordinates. Rows are centroids, columns are terms.
             distances (np.ndarray): An array of distances between documents and centroids. Rows are centroids, columns are documents.
         '''
 
+        random.seed(random_state)
         matrix_shape = matrix.shape
         centroid_coordinates = np.zeros((number_of_centroids, matrix_shape[1]))#Rows are centroids, columns are terms
         distances = np.zeros((number_of_centroids, matrix_shape[0]))#Rows are centroids, columns are documents

--- a/src/tests/k_means_test.py
+++ b/src/tests/k_means_test.py
@@ -7,17 +7,42 @@ class TestKmeans(unittest.TestCase):
         self.matrix = np.array([[1,2,3,5,6], [4,5,6,6,5], [7,8,1,2,9], [6,6,6,7,8], [2,1,2,2,1]])
         self.centroids = np.array([[3,3,3,3,3], [5,5,5,5,5], [1,1,1,1,1]])
         self.k_means = Kmeans()
-        
+        self.random_state = 42
+
     def test_initialize_centroids(self):
-        centroid_coordinates, distances = self.k_means.initialize_centroids(self.matrix, 3)
+        centroid_coordinates, distances = self.k_means.initialize_centroids(self.matrix, 3, random_state=self.random_state)
         number_of_zeros = np.sum(distances == 0)
         self.assertEqual(centroid_coordinates.any(), self.matrix.any())
         self.assertEqual(number_of_zeros, 3)
+
+    def test_initialize_centroids_is_deterministic(self):
+        coords1, dists1 = self.k_means.initialize_centroids(self.matrix, 3, random_state=self.random_state)
+        coords2, dists2 = self.k_means.initialize_centroids(self.matrix, 3, random_state=self.random_state)
+        np.testing.assert_array_equal(coords1, coords2)
+        np.testing.assert_array_equal(dists1, dists2)
+
+    def test_initialize_centroids_different_seeds_differ(self):
+        coords1, _ = self.k_means.initialize_centroids(self.matrix, 3, random_state=42)
+        coords2, _ = self.k_means.initialize_centroids(self.matrix, 3, random_state=99)
+        self.assertFalse(np.array_equal(coords1, coords2))
+
+    def test_initialize_centroids_rows_are_from_matrix(self):
+        coords, _ = self.k_means.initialize_centroids(self.matrix, 3, random_state=self.random_state)
+        for row in coords:
+            self.assertTrue(any(np.array_equal(row, doc) for doc in self.matrix))
 
     def test_euclidean_distance(self):
         correct = 5.385164807134504
         distance = self.k_means.euclidean_distance(self.matrix[0], self.matrix[1])
         self.assertEqual(distance, correct)
+
+    def test_euclidean_distance_same_point_is_zero(self):
+        self.assertEqual(self.k_means.euclidean_distance(self.matrix[0], self.matrix[0]), 0.0)
+
+    def test_euclidean_distance_is_symmetric(self):
+        d1 = self.k_means.euclidean_distance(self.matrix[0], self.matrix[2])
+        d2 = self.k_means.euclidean_distance(self.matrix[2], self.matrix[0])
+        self.assertAlmostEqual(d1, d2)
 
     def test_get_clusters(self):
         correct = np.array([0, 4, 2, 2, 4])
@@ -31,6 +56,11 @@ class TestKmeans(unittest.TestCase):
         distances = np.zeros((3,5))
         distances = self.k_means.calculate_distances(self.matrix, distances, self.centroids)
         self.assertEqual(distances.all(), correct.all())
+
+    def test_calculate_distances_shape(self):
+        distances = np.zeros((3, 5))
+        result = self.k_means.calculate_distances(self.matrix, distances, self.centroids)
+        self.assertEqual(result.shape, (3, 5))
 
     def test_calculate_new_centroid_coordinates(self):
         correct = np.array([[1, 2, 3, 5, 6], [5, 6, 4, 5, 7], [2, 1, 2, 2, 1]])
@@ -48,3 +78,10 @@ class TestKmeans(unittest.TestCase):
         centroid_coordinates, clusters = self.k_means.run_k_means(self.matrix, self.centroids, distances, 3)
         self.assertEqual(centroid_coordinates.all(), correct_centroid_coordinates.all())
         self.assertEqual(clusters.all(), correct_clusters.all())
+
+    def test_run_k_means_converges(self):
+        distances = np.zeros((3,5))
+        distances = self.k_means.calculate_distances(self.matrix, distances, self.centroids)
+        _, clusters1 = self.k_means.run_k_means(self.matrix, self.centroids.copy(), distances, 10)
+        _, clusters2 = self.k_means.run_k_means(self.matrix, self.centroids.copy(), distances, 100)
+        np.testing.assert_array_equal(clusters1, clusters2)


### PR DESCRIPTION
This PR is part of an ongoing research effort and focuses on improving test reliability. It introduces support for a random seed to make test execution deterministic and easier to debug. Previously, `initialize_centroids` relied on `random.randint` without a fixed seed, leading to non-deterministic behavior across test runs.

## Changes

- Added an optional `random_state` parameter to `initialize_centroids`.
  - Defaults to `None`, preserving existing behavior.
  - When provided, it seeds the random number generator to ensure reproducible results.

- Updated the existing test to use `random_state=42`.

- Added 7 new tests covering:
  - Determinism
  - Symmetry
  - Output shape
  - Convergence
  - Edge cases

## Impact

- No breaking changes.
- Existing behavior remains unchanged when `random_state` is not provided.
- Improved test stability and reliability.